### PR TITLE
Add patient enrichment and backend sync features

### DIFF
--- a/final_utils_upd.py
+++ b/final_utils_upd.py
@@ -38,6 +38,11 @@ from clustering_utils import (
     cluster_patients
 )
 
+from utils.enrichment_utils import enrich_patient_phlebotomist_fields
+from utils.backend_sync import sync_patients_to_backend
+import pandas as pd
+import os
+
 # Re-export all functions to maintain API compatibility
 __all__ = [
     # Route utilities
@@ -71,5 +76,21 @@ __all__ = [
     'get_cities_by_date',
     
     # Clustering utilities
-    'cluster_patients'
+    'cluster_patients',
+    'enrich_patient_phlebotomist_fields',
+    'sync_patients_to_backend',
+    'save_enriched_patients'
 ]
+
+
+def save_enriched_patients(enriched_df: pd.DataFrame, target_date, target_city) -> str:
+    """Save enriched patients dataframe to CSV and return the path."""
+    output_dir = os.path.join('GeneratedFiles')
+    os.makedirs(output_dir, exist_ok=True)
+    date_str = pd.to_datetime(target_date).strftime('%Y-%m-%d')
+    city_str = str(target_city).replace(' ', '')
+    filename = f'enriched_patients_{date_str}_{city_str}.csv'
+    path = os.path.join(output_dir, filename)
+    enriched_df.to_csv(path, index=False)
+    return os.path.relpath(path).replace('\\', '/')
+

--- a/utils/backend_sync.py
+++ b/utils/backend_sync.py
@@ -1,0 +1,29 @@
+import logging
+from typing import Tuple
+import pandas as pd
+import requests
+
+
+def sync_patients_to_backend(api_url: str, enriched_df: pd.DataFrame) -> Tuple[bool, str]:
+    """Send enriched patient records to backend API.
+
+    Parameters
+    ----------
+    api_url : str
+        Endpoint URL to send the records to.
+    enriched_df : pd.DataFrame
+        Dataframe of patients to sync.
+
+    Returns
+    -------
+    Tuple[bool, str]
+        Success flag and response or error message.
+    """
+    try:
+        response = requests.post(api_url, json=enriched_df.to_dict(orient='records'))
+        if response.status_code == 200:
+            return True, response.text
+        return False, f"{response.status_code}: {response.text}"
+    except Exception as exc:
+        logging.getLogger(__name__).error("Backend sync failed", exc_info=True)
+        return False, str(exc)

--- a/utils/enrichment_utils.py
+++ b/utils/enrichment_utils.py
@@ -1,0 +1,106 @@
+import pandas as pd
+import logging
+import os
+import re
+from typing import Tuple
+
+
+def enrich_patient_phlebotomist_fields(
+    patient_df: pd.DataFrame,
+    phleb_df: pd.DataFrame,
+    log_file_path: str
+) -> pd.DataFrame:
+    """Fill missing phlebotomist related fields on patient records.
+
+    Only updates fields that are null. Uses phleb_df metadata matched by
+    ``AssignedPhlebID`` on the patient record and ``PhlebotomistID.1`` on the
+    phlebotomist dataframe.
+
+    Parameters
+    ----------
+    patient_df : pd.DataFrame
+        Assigned patient dataframe.
+    phleb_df : pd.DataFrame
+        Phlebotomist metadata dataframe.
+    log_file_path : str
+        Path to log file for skipped enrichments.
+
+    Returns
+    -------
+    pd.DataFrame
+        New dataframe with enriched fields.
+    """
+    os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+    logger = logging.getLogger(__name__)
+    if not any(isinstance(h, logging.FileHandler) and h.baseFilename == os.path.abspath(log_file_path)
+               for h in logger.handlers):
+        handler = logging.FileHandler(log_file_path)
+        formatter = logging.Formatter('%(asctime)s %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    patients = patient_df.copy()
+
+    # prepare phlebotomist dataframe for merge
+    phleb_merge = phleb_df.copy()
+    phleb_merge['AssignedPhlebID'] = phleb_merge['PhlebotomistID.1'].astype(str)
+    phleb_merge = phleb_merge.rename(columns={
+        'PhlebotomistID.1': 'PhlebotomistID',
+        'PhlebotomistName': 'PhlebotomistName_src',
+        'City': 'PhlebotmistCity'
+    })
+
+    merge_cols = [
+        'AssignedPhlebID',
+        'PhlebotomistID',
+        'PhlebotomistName_src',
+        'PhlebotmistCity',
+        'PhlebotomistLatitude',
+        'PhlebotomistLongitude'
+    ]
+
+    optional_cols = ['PhlebotomistStreet1', 'PhlebotomistZip', 'DropOffLocation']
+    for col in optional_cols:
+        if col in phleb_merge.columns and col not in merge_cols:
+            merge_cols.append(col)
+
+    patients = patients.merge(phleb_merge[merge_cols], on='AssignedPhlebID', how='left', suffixes=('', '_phleb'))
+
+    def valid_name(name: str) -> bool:
+        return bool(re.fullmatch(r'[A-Za-z0-9\s]+', str(name)))
+
+    duplicate_names = phleb_merge['PhlebotomistName_src'].value_counts()
+    duplicate_names = set(duplicate_names[duplicate_names > 1].index)
+
+    # Field mapping of patient column -> phleb merge column
+    field_map = {
+        'PhlebotomistID': 'PhlebotomistID',
+        'PhlebotomistName': 'PhlebotomistName_src',
+        'PhlebotmistCity': 'PhlebotmistCity',
+        'PhlebotomistLatitude': 'PhlebotomistLatitude',
+        'PhlebotomistLongitude': 'PhlebotomistLongitude',
+        'PhlebotomistStreet1': 'PhlebotomistStreet1',
+        'PhlebotomistZip': 'PhlebotomistZip',
+        'DropOffLocation': 'DropOffLocation'
+    }
+
+    for patient_col, phleb_col in field_map.items():
+        if patient_col not in patients.columns or phleb_col not in patients.columns:
+            continue
+        if patient_col == 'PhlebotomistName':
+            mask = patients[patient_col].isna()
+            name_candidates = patients.loc[mask, phleb_col]
+            valid_mask = name_candidates.apply(lambda x: valid_name(x) and x not in duplicate_names)
+            invalid = patients.loc[mask & ~valid_mask, ['AssignedPhlebID', phleb_col]]
+            for _, row in invalid.iterrows():
+                logger.info(f"Skipped name for PhlebID {row['AssignedPhlebID']} -> {row[phleb_col]}")
+            patients.loc[mask & valid_mask, patient_col] = name_candidates[valid_mask]
+        else:
+            mask = patients[patient_col].isna()
+            patients.loc[mask, patient_col] = patients.loc[mask, phleb_col]
+
+    # Drop the extra merged columns created during the merge
+    patients = patients.drop(columns=[c for c in patients.columns if c.endswith('_phleb')])
+
+    return patients


### PR DESCRIPTION
## Summary
- add utils/enrichment_utils and utils/backend_sync helpers
- expose new helpers from final_utils_upd
- enrich assigned patient data in `app.py`
- allow downloading enriched patients and syncing to backend

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_b_683fce1b45e08325aadd4b04bf27ef35